### PR TITLE
Bump lib-gh from 0.6.0 to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lib-gh",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lib-gh",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "vue": "^3.3.8"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-gh",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
```diff <!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>versions should be min then max</pre>
</body>
</html> ``` Diff url: https://diff.intrinsic.com/lib-gh/0.6.0/0.1.0.diff