### PR TITLE
Bump lib-gh from 0.7.0 to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lib-gh",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lib-gh",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "vue": "^3.3.8"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-gh",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
```diff diff --new-file '--unified=3' --recursive --expand-tabs '--tabsize=2' --unidirectional-new-file --ignore-space-change --ignore-trailing-space --ignore-blank-lines lib-gh-0.7.0/package/package.json lib-gh-0.8.0/package/package.json
--- lib-gh-0.7.0/package/package.json	1985-10-26 08:15:00.000000000 +0000
+++ lib-gh-0.8.0/package/package.json	1985-10-26 08:15:00.000000000 +0000
@@ -1,6 +1,6 @@
 {
   "name": "lib-gh",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "files": [
     "dist" ``` Diff url: https://diff.intrinsic.com/lib-gh/0.7.0/0.8.0.diff